### PR TITLE
Add translate button to quote actions

### DIFF
--- a/src/components/quote/action-buttons.tsx
+++ b/src/components/quote/action-buttons.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState } from 'react'
 import { IoCopyOutline, IoCheckmark } from 'react-icons/io5'
-import { TbRefresh } from 'react-icons/tb'
+import { TbRefresh, TbLanguage } from 'react-icons/tb'
 import {
 	Tooltip,
 	TooltipContent,
@@ -105,6 +105,30 @@ export default function ActionButtons({
 		}
 	}
 
+	const handleTranslate = () => {
+		try {
+			// Encode the quote text for a URL
+			const encodedQuote = encodeURIComponent(quote)
+
+			// Create Google Translate URL with the quote prefilled
+			const translateUrl = `https://translate.google.com/?text=${encodedQuote}`
+
+			// Open Google Translate in a new tab
+			window.open(translateUrl, '_blank')
+
+			toast.success('Opening Google Translate', {
+				position: 'bottom-right',
+				duration: 2000,
+			})
+		} catch (error) {
+			console.error('Error opening Google Translate:', error)
+			toast.error('Failed to open Google Translate', {
+				position: 'bottom-right',
+				duration: 2000,
+			})
+		}
+	}
+
 	return (
 		<>
 			<div className='absolute z-1 -top-10.5 right-4 bg-black/10 border-t border-l border-r border-white/10 backdrop-blur-sm rounded-lg p-2 transform transition-all duration-300 opacity-0 group-hover:opacity-100 translate-y-2 group-hover:translate-y-0'>
@@ -169,7 +193,7 @@ export default function ActionButtons({
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<button
-								className='text-white/80 border-l border-white/30 pl-2 hover:text-white transition-colors duration-200'
+								className='text-white/80 border-l border-white/30 px-2 hover:text-white transition-colors duration-200'
 								onClick={handleRefresh}
 								disabled={isRefreshing}
 							>
@@ -182,6 +206,22 @@ export default function ActionButtons({
 						</TooltipTrigger>
 						<TooltipContent>
 							<p>{isRefreshing ? 'Loading...' : 'New Quote'}</p>
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
+
+				<TooltipProvider>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								className='text-white/80 border-l border-white/30 px-2 hover:text-white transition-colors duration-200'
+								onClick={handleTranslate}
+							>
+								<TbLanguage className='h-5 w-5' />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent>
+							<p>Translate</p>
 						</TooltipContent>
 					</Tooltip>
 				</TooltipProvider>


### PR DESCRIPTION
   This PR adds a Google Translate button to the quote actions panel. Features:
   - One-click access to translate the current quote
   - Opens Google Translate in a new tab with the quote pre-filled
   - Matches existing UI style and interactions
   - Provides user feedback via toast notifications